### PR TITLE
Support for custom header comment

### DIFF
--- a/GitHubAction.pkl
+++ b/GitHubAction.pkl
@@ -679,16 +679,19 @@ permissions: (*Permissions|"read-all"|"write-all")?
 jobs: Jobs
 
 // Output
-local jsonRenderer = new JsonRenderer {}
+local baseHeaderComment = "# Do not modify!\n# This file was generated from a template using https://github.com/StefMa/pkl-gha"
+headerComment: String? = null
+local finalHeaderComment: String = if (headerComment != null) "\(headerComment)\n\n" + baseHeaderComment else baseHeaderComment
 output {
-  text = "# Do not modify!\n# This file was generated from a template using https://github.com/StefMa/pkl-gha\n\n\(super.text)"
+  text = "\(finalHeaderComment)\n\n\(super.text)"
   renderer = new YamlRenderer {
     converters {
       ["runs-on"] = (runsOn: String|Machine|Listing<String|Machine>) ->
         if (runsOn is Listing<String|Machine>) convertMachinesToString(runsOn) else convertMachineToString(runsOn)
       ["schedule"] = (schedule: Schedule?) -> schedule.ifNonNull((_) ->
-        schedule.cron.toList().map((cr) -> Map("cron", new RenderDirective { text = " " + jsonRenderer.renderValue(cr) }))
+        schedule.cron.toList().map((cr) -> Map("cron", new RenderDirective { text = " " + new JsonRenderer {}.renderValue(cr) }))
       )
+      ["headerComment"] = (headerComment: String?) -> null
     }
   }
 }

--- a/examples/HeaderComment.pkl
+++ b/examples/HeaderComment.pkl
@@ -1,0 +1,31 @@
+amends "../GitHubAction.pkl"
+
+headerComment = """
+  # SPDX-FileCopyrightText: Copyright line here
+  #
+  # SPDX-License-Identifier: License here
+  """
+
+name = "Custom header comment"
+
+on {
+  push {
+    branches {
+      "main"
+    }
+  }
+}
+
+jobs {
+  ["headerComment"] {
+    `runs-on` = "ubuntu-latest"
+    steps {
+      new {
+        uses = "actions/checkout@v4"
+      }
+      new {
+        run = "echo Hello World"
+      }
+    }
+  }
+}

--- a/tests/GitHubAction.pkl
+++ b/tests/GitHubAction.pkl
@@ -21,6 +21,9 @@ examples {
   ["reusableWorkflow"] {
     import("../examples/ReusableWorkflow.pkl").output.text
   }
+  ["headerComment"] {
+    import("../examples/HeaderComment.pkl").output.text
+  }
 }
 
 facts {

--- a/tests/GitHubAction.pkl-expected.pcf
+++ b/tests/GitHubAction.pkl-expected.pcf
@@ -240,4 +240,27 @@ examples {
     
     """
   }
+  ["headerComment"] {
+    """
+    # SPDX-FileCopyrightText: Copyright line here
+    #
+    # SPDX-License-Identifier: License here
+    
+    # Do not modify!
+    # This file was generated from a template using https://github.com/StefMa/pkl-gha
+    
+    name: Custom header comment
+    'on':
+      push:
+        branches:
+        - main
+    jobs:
+      headerComment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v4
+        - run: echo Hello World
+    
+    """
+  }
 }


### PR DESCRIPTION
Contributes to #33 
Adds support for a custom header comment.

@NayanTheSpaceGuy is this you're looking for? 🙃 

You can just override `headerComment` like:
```
headerComment = """
  # SPDX-FileCopyrightText: Copyright line here
  #
  # SPDX-License-Identifier: License here
  """
```

Honestly, I'm not sure if this is the elegantes solution as it shouldn't be part of the templating I guess 🤔 

Maybe introducing a bucket like `pklGhaSettings { }` or so would be better? 🤔 