### PR TITLE
fix: Add attestation to permissions class

### DIFF
--- a/Workflow.pkl
+++ b/Workflow.pkl
@@ -535,6 +535,7 @@ typealias EnvironmentVariables = Mapping<String, String|Boolean|Number>
 // Permissions
 class Permissions {
   actions: Permission?
+  attestations: Permission?
   checks: Permission?
   contents: Permission?
   deployments: Permission?


### PR DESCRIPTION
Adds attestations to the permissions class, as documented [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
