### PR TITLE
Update the workflow_call.secrets to be a mapping

### DIFF
--- a/Workflow.pkl
+++ b/Workflow.pkl
@@ -444,7 +444,7 @@ class Watch extends Trigger
 class WorkflowCall extends Trigger {
   inputs: Mapping<String, WorkflowInput>?
   outputs: Mapping<String, WorkflowCallOutput>?
-  secrets: Listing<WorkflowCallSecrets>?
+  secrets: Mapping<String, WorkflowCallSecrets>?
 }
 class WorkflowCallOutput {
   description: String?


### PR DESCRIPTION
These must be specified as a mapping, similar to how `workflow_call.input` works, because they have to have a name as well as a value, not just a value

The generated yaml should look something like this

```yml
on:
  workflow_call:
    secrets:
      ssh_key:
        required: true
        description: "The SSH key to use"
```
