### PR TITLE
Feat/add actionlint

### DIFF
--- a/.github/pkl-workflows/CheckActionlintExamples.pkl
+++ b/.github/pkl-workflows/CheckActionlintExamples.pkl
@@ -1,0 +1,43 @@
+amends "@gha/Workflow.pkl"
+import "modules/Steps.pkl"
+
+name = "CheckActionlintExamples"
+
+on {
+  push {}
+}
+
+jobs {
+  ["actionlintWorkflows"] {
+    `runs-on` = new UbuntuLatest {}
+
+    steps {
+      ...Steps.checkoutAndInstallPkl
+      new {
+        name = "Convert pkl examples to yaml"
+        `working-directory` = "examples"
+        run =
+          """
+          pkl eval *.pkl -o yaml/%{moduleName}.generated.yml
+          """
+      }
+      Steps.setupGo
+      new {
+        name = "Install actionlint CLI"
+        `working-directory` = "examples"
+        run =
+          """
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          """
+      }
+      new {
+        name = "Run actionlint on examples"
+        `working-directory` = "examples"
+        run =
+          """
+          ./actionlint -ignore 'could not read reusable workflow file' yaml/*.generated.yml
+          """
+      }
+    }
+  }
+}

--- a/.github/pkl-workflows/modules/Steps.pkl
+++ b/.github/pkl-workflows/modules/Steps.pkl
@@ -1,4 +1,5 @@
 import "@gha/actions/Common.pkl"
+import "@gha/actions/Setup.pkl"
 import "@gha/Workflow.pkl"
 import "@setup.pkl/Action.pkl" as SetupPkl
 
@@ -16,4 +17,8 @@ installPkl: SetupPkl.Action = new {
 checkoutAndInstallPkl: Listing<Workflow.TypedStep> = new {
   checkout
   installPkl
+}
+
+setupGo: Setup.Go = new {
+  name = "Setup Go"
 }

--- a/.github/workflows/CheckActionlintExamples.generated.yml
+++ b/.github/workflows/CheckActionlintExamples.generated.yml
@@ -1,0 +1,27 @@
+# Do not modify!
+# This file was generated from a template using https://github.com/StefMa/pkl-gha
+
+name: CheckActionlintExamples
+'on':
+  push: {}
+jobs:
+  actionlintWorkflows:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v5
+    - name: Install pkl
+      uses: pkl-community/setup-pkl@v0.0.8
+      with:
+        pkl-version: 0.30.0
+    - name: Convert pkl examples to yaml
+      working-directory: examples
+      run: pkl eval *.pkl -o yaml/%{moduleName}.generated.yml
+    - name: Setup Go
+      uses: actions/setup-go@v6
+    - name: Install actionlint CLI
+      working-directory: examples
+      run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+    - name: Run actionlint on examples
+      working-directory: examples
+      run: ./actionlint -ignore 'could not read reusable workflow file' yaml/*.generated.yml

--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ For other platforms, please follow the [official installation guide](https://pkl
 **3. Convert the Pkl file to Yaml**
 
 ```bash
-pkl eval path/to/your/pkl/file.pkl -o path/to/your/pkl/file.yaml
+pkl eval path/to/your/pkl/file.pkl -o path/to/output/yml/file.yaml
 ```
 
 *Or alternatively for all files in the `.github/workflows` directory*:
 ```bash
-pkl eval path/to/your/pkl/files/*.pkl -o path/to/your/pkl/files/%{moduleName}.yml
+pkl eval path/to/your/pkl/files/*.pkl -o path/to/output/yml/files/%{moduleName}.yml
 ```
 
 ## Why?

--- a/examples/TestWorkflow.pkl
+++ b/examples/TestWorkflow.pkl
@@ -64,10 +64,6 @@ jobs {
   ["hello_dependabot"] {
     `runs-on` = new MacOsLatest {}
     `if` = Context.github.custom("actor == 'dependabot[bot]'")
-    needs {
-      "first_job"
-      "second_job"
-    }
     permissions = "write-all"
     environment {
       name = "production"
@@ -104,7 +100,7 @@ jobs {
   }
   ["print"] {
     `runs-on` = new Listing {
-      "macos-latest"
+      "self-hosted"
       new WindowsLatest {}
     }
     environment = "staging"

--- a/examples/WorkflowTriggers.pkl
+++ b/examples/WorkflowTriggers.pkl
@@ -39,7 +39,7 @@ on {
       cron = "5 4 * * *"
     }
     new {
-      cron = "* 0 * * 0"
+      cron = "10,15 0 * * 0"
     }
   }
   status {}

--- a/tests/Workflow.pkl-expected.pcf
+++ b/tests/Workflow.pkl-expected.pcf
@@ -3,7 +3,7 @@ examples {
     #"""
     # Do not modify!
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
-    
+
     name: PrintHelloWorld
     'on':
       pull_request:
@@ -45,9 +45,6 @@ examples {
     jobs:
       hello_dependabot:
         if: ${{ github.actor == 'dependabot[bot]' }}
-        needs:
-        - first_job
-        - second_job
         permissions: write-all
         runs-on: macos-latest
         outputs:
@@ -74,7 +71,7 @@ examples {
       print:
         needs: hello_dependabot
         runs-on:
-        - macos-latest
+        - self-hosted
         - windows-latest
         environment: staging
         steps:
@@ -94,14 +91,14 @@ examples {
             some_bool: true
             some_number: 5
             payload: "{\n\t\"blocks\": [\n\t\t{\n    \"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"mrkdwn\",\n\t\t\t\t\"text\": \":alert: Develop is broken!\"\n\t\t\t}\n\t\t}\n\t]\n}"
-    
+
     """#
   }
   ["workflowTriggers"] {
     """
     # Do not modify!
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
-    
+
     name: GitHub Action Triggers
     'on':
       branch_protection_rule: {}
@@ -135,7 +132,7 @@ examples {
       schedule:
       - cron: '*/10 * * * *'
       - cron: 5 4 * * *
-      - cron: '* 0 * * 0'
+      - cron: 10,15 0 * * 0
       status: {}
       watch: {}
       workflow_call: {}
@@ -149,14 +146,14 @@ examples {
         steps:
         - name: Hello
           run: echo 'Hello, World!'
-    
+
     """
   }
   ["updateWikiReadme"] {
     """
     # Do not modify!
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
-    
+
     name: Update Wiki Readme
     'on':
       push:
@@ -181,14 +178,14 @@ examples {
             git add wiki/README.md || echo "No changes to commit"
             git commit -m 'Re-build TOC in README.md' || echo "No changes to commit"
             git push origin || echo "No changes to commit"
-    
+
     """
   }
   ["matrixTest"] {
     """
     # Do not modify!
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
-    
+
     name: Matrix Test
     'on':
       push:
@@ -217,14 +214,14 @@ examples {
           uses: actions/checkout@v5
         - name: Run on ${{ matrix.os }}
           run: echo Hello World
-    
+
     """
   }
   ["reusableWorkflow"] {
     """
     # Do not modify!
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
-    
+
     name: Reusable Workflow
     'on':
       push:
@@ -245,14 +242,14 @@ examples {
         secrets:
           SECRET TOKEN: TOKEN
           ANOTHER SECRET: 42
-    
+
     """
   }
   ["prebuildActions"] {
     """
     # Do not modify!
     # This file was generated from a template using https://github.com/StefMa/pkl-gha
-    
+
     name: Check prebuild actions
     'on':
       push: {}
@@ -279,7 +276,7 @@ examples {
             path: tmp-doc
         - id: deployment
           uses: actions/deploy-pages@v4
-    
+
     """
   }
 }


### PR DESCRIPTION
Following the mess on PR #64.

It's not as lightweight as you did for the CI (taking almost twice the time compared to the other workflows 11s instead of 5-6s).

I adapted some examples files for `actionlint` to not raise warning and ignored the warning concerning the missing files for the `uses: ./something.yaml`

I didn't took the time to set in stone the go version (not sure how I could make it depend on the `actionlint` requirements. The `actionlint` is also set to use the latest version.